### PR TITLE
Fix git links for libmaus2 and biobambam2 repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,45 +6,51 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ENV LD_LIBRARY_PATH /usr/local/lib
 
+# Install dependencies
 RUN apt-get update \
-    && apt-get install -y \
-        autoconf \
-        curl \
-        g++ \
-        libtool \
-        pkg-config \
-        zlib1g-dev \
-    && apt-get clean \
-    && rm -rf /usr/local/* \
-    && curl --silent https://gitlab.com/german.tischler/libmaus2/repository/archive.tar.gz\?ref\=2.0.610-release-20190328154814 -o libmaus2.tar.gz \
-    && curl --silent https://gitlab.com/german.tischler/biobambam2/repository/archive.tar.gz\?ref\=2.0.95-release-20190320141403 -o biobambam2.tar.gz \
-    && libmaus2files=$(tar -axvf libmaus2.tar.gz) \
-    && libmaus2dir=$(echo ${libmaus2files} | cut -f1 -d" ") \
-    && cd ${libmaus2dir} \
-    && libtoolize \
-    && aclocal \
-    && autoreconf -i -f \
-    && ./configure \
-    && make -j4 \
-    && make install \
-    && cd ../ \
-    && rm -rf ${libmaus2dir} libmaus2.tar.gz \
-    && biobambam2files=$(tar -axvf biobambam2.tar.gz) \
-    && biobambam2dir=$(echo ${biobambam2files} | cut -f1 -d" ") \
-    && cd ${biobambam2dir} \
-    && export LIBMAUSPREFIX=/usr/local \
-    && autoreconf -i -f \
-    && ./configure --with-libmaus2=${LIBMAUSPREFIX} \
-    && make -j4 \
-    && make install \
-    && cd ../ \
-    && rm -rf ${biobambam2dir} biobambam2.tar.gz \
-    && apt-get remove --purge -y \
-        autoconf \
-        curl \
-        g++ \
-        libtool \
-        pkg-config \
-        zlib1g-dev \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ && apt-get install -y \
+    autoconf \
+    curl \
+    g++ \
+    git \
+    libtool \
+    make \
+    pkg-config \
+    zlib1g-dev \
+ && apt-get clean \
+ && rm -rf /usr/local/*
+
+# Install libmaus2
+RUN git clone https://gitlab.com/german.tischler/libmaus2.git --branch 2.0.610-release-20190328154814  \
+ && cd libmaus2 \
+ && libtoolize \
+ && aclocal \
+ && autoreconf -i -f \
+ && ./configure \
+ && make -j4 \
+ && make install \
+ && cd ../
+
+# Install biobambam2
+RUN git clone https://gitlab.com/german.tischler/biobambam2.git --branch 2.0.95-release-20190320141403 \
+ && cd biobambam2 \
+ && export LIBMAUSPREFIX=/usr/local \
+ && autoreconf -i -f \
+ && ./configure --with-libmaus2=${LIBMAUSPREFIX} \
+ && make -j4 \
+ && make install \
+ && cd ../
+
+# Clean dependencies
+RUN apt-get remove --purge -y \
+    autoconf \
+    curl \
+    g++ \
+    git \
+    libtool \
+    make \
+    pkg-config \
+    zlib1g-dev \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp
+


### PR DESCRIPTION
# Addressed Issue
- Address [biobambam build issue #5 ](https://github.com/ohsu-comp-bio/wgs-pipelines/issues/5)

# Changes
- Fixes links to Gitlab repos using Kyle's recommendation 
- Splits `RUN` commands (optional, can revert if not necessary)

# Tests
- Ran `docker build -t biobambam .` successfully, can push built image to Quay.io or Dockerhub if that would be helpful.

```sh
➜  biobambam-docker git:(master) ✗ docker build -t biobambam .
[+] Building 737.6s (9/9) FINISHED                                                 docker:desktop-linux
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 1.21kB                                                             0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                    0.0s
 => CACHED [1/5] FROM docker.io/library/ubuntu:20.04                                               0.0s
 => [2/5] RUN apt-get update  && apt-get install -y     autoconf     curl     g++     git     li  43.3s
 => [3/5] RUN git clone https://gitlab.com/german.tischler/libmaus2.git --branch 2.0.610-releas  373.2s
 => [4/5] RUN git clone https://gitlab.com/german.tischler/biobambam2.git --branch 2.0.95-relea  313.2s
 => [5/5] RUN apt-get remove --purge -y     autoconf     curl     g++     git     libtool     mak  6.3s
 => exporting to image                                                                             1.5s
 => => exporting layers                                                                            1.5s
 => => writing image sha256:6bc561986ace5f260277f20740705e2aece9dc6961944382caf24994590b8066       0.0s
 => => naming to docker.io/library/biobambam                                                       0.0s
```